### PR TITLE
Added optional param for selecting a branch other than trunk for checkout.

### DIFF
--- a/scripts/checkout-all.sh
+++ b/scripts/checkout-all.sh
@@ -1,30 +1,36 @@
 #/usr/bin/env sh
 
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonDatasets/trunk ApiCommonDatasets
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonModel/trunk ApiCommonModel
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonPresenters/trunk ApiCommonPresenters
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonWebService/trunk ApiCommonWebService
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonWebsite/trunk ApiCommonWebsite
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/CBIL/trunk CBIL
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiDatasets/trunk ClinEpiDatasets
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiModel/trunk ClinEpiModel
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiPresenters/trunk ClinEpiPresenters
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiWebsite/trunk ClinEpiWebsite
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/DJob/trunk DJob
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/EbrcModelCommon/trunk EbrcModelCommon
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/EbrcWebSvcCommon/trunk EbrcWebSvcCommon
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/EbrcWebsiteCommon/trunk EbrcWebsiteCommon
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/FgpUtil/trunk FgpUtil
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/GBrowse/trunk GBrowse
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomeDatasets/trunk MicrobiomeDatasets
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomeModel/trunk MicrobiomeModel
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomePresenters/trunk MicrobiomePresenters
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomeWebsite/trunk MicrobiomeWebsite
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/OrthoMCLModel/trunk OrthoMCLModel
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/OrthoMCLWebService/trunk OrthoMCLWebService
-svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/OrthoMCLWebsite/trunk OrthoMCLWebsite
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/ReFlow/trunk ReFlow
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/TuningManager/trunk TuningManager
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/WDK/trunk WDK
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/WSF/trunk WSF
-svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/install/trunk install
+if [ -z "$1" ]; then
+  BRANCH="trunk"
+else
+  BRANCH="branches/$1"
+fi
+
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonDatasets/$BRANCH ApiCommonDatasets
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonModel/$BRANCH ApiCommonModel
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonPresenters/$BRANCH ApiCommonPresenters
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonWebService/$BRANCH ApiCommonWebService
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ApiCommonWebsite/$BRANCH ApiCommonWebsite
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/CBIL/$BRANCH CBIL
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiDatasets/$BRANCH ClinEpiDatasets
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiModel/$BRANCH ClinEpiModel
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiPresenters/$BRANCH ClinEpiPresenters
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/ClinEpiWebsite/$BRANCH ClinEpiWebsite
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/DJob/$BRANCH DJob
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/EbrcModelCommon/$BRANCH EbrcModelCommon
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/EbrcWebSvcCommon/$BRANCH EbrcWebSvcCommon
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/EbrcWebsiteCommon/$BRANCH EbrcWebsiteCommon
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/FgpUtil/$BRANCH FgpUtil
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/GBrowse/$BRANCH GBrowse
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomeDatasets/$BRANCH MicrobiomeDatasets
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomeModel/$BRANCH MicrobiomeModel
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomePresenters/$BRANCH MicrobiomePresenters
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/MicrobiomeWebsite/$BRANCH MicrobiomeWebsite
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/OrthoMCLModel/$BRANCH OrthoMCLModel
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/OrthoMCLWebService/$BRANCH OrthoMCLWebService
+svn co https://cbilsvn.pmacs.upenn.edu/svn/apidb/OrthoMCLWebsite/$BRANCH OrthoMCLWebsite
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/ReFlow/$BRANCH ReFlow
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/TuningManager/$BRANCH TuningManager
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/WDK/$BRANCH WDK
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/WSF/$BRANCH WSF
+svn co https://cbilsvn.pmacs.upenn.edu/svn/gus/install/$BRANCH install


### PR DESCRIPTION
Defaults to `{project}/trunk` if no param provided (the previous usage form), if a param _is_ provided it will checkout from `{project}/branches/{input param}`

Tested manually with a full checkout from both `trunk` as well as my current feature branch.